### PR TITLE
Initial Work for packer-janitor lambda module

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,17 @@
+version: 2
+jobs:
+  build:
+    docker:
+      - image: trussworks/circleci-docker-primary:5ca2def958c1a6abbb6ac7668c13ecee5b4598e1
+    steps:
+      - checkout
+      - restore_cache:
+          keys:
+            - pre-commit-dot-cache-{{ checksum ".pre-commit-config.yaml" }}
+      - run:
+          name: Run pre-commit tests
+          command: pre-commit run --all-files
+      - save_cache:
+          key: pre-commit-dot-cache-{{ checksum ".pre-commit-config.yaml" }}
+          paths:
+            - ~/.cache

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,8 +1,8 @@
 version: 2
 jobs:
-  build:
+  validate:
     docker:
-      - image: trussworks/circleci-docker-primary:5ca2def958c1a6abbb6ac7668c13ecee5b4598e1
+      - image: trussworks/circleci-docker-primary:a18ba9987556eec2e48354848a3c9fb4d5b69ac8
     steps:
       - checkout
       - restore_cache:
@@ -14,4 +14,10 @@ jobs:
       - save_cache:
           key: pre-commit-dot-cache-{{ checksum ".pre-commit-config.yaml" }}
           paths:
-            - ~/.cache
+            - ~/.cache/pre-commit
+
+workflows:
+  version: 2
+  validate:
+    jobs:
+      - validate

--- a/.markdownlintrc
+++ b/.markdownlintrc
@@ -1,0 +1,7 @@
+{
+  "default": true,
+  "first-header-h1": false,
+  "first-line-h1": false,
+  "line_length": false,
+  "no-multiple-blanks": false
+}

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,24 @@
+repos:
+  - repo: git://github.com/pre-commit/pre-commit-hooks
+    rev: v2.0.0
+    hooks:
+      - id: check-json
+      - id: check-merge-conflict
+      - id: check-yaml
+      - id: detect-private-key
+      - id: pretty-format-json
+        args:
+          - --autofix
+      - id: trailing-whitespace
+
+  - repo: git://github.com/igorshubovych/markdownlint-cli
+    rev: v0.13.0
+    hooks:
+      - id: markdownlint
+
+  - repo: git://github.com/antonbabenko/pre-commit-terraform
+    rev: v1.7.3
+    hooks:
+      - id: terraform_docs
+      - id: terraform_fmt
+      - id: terraform_validate_no_variables

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
   - repo: git://github.com/pre-commit/pre-commit-hooks
-    rev: v2.0.0
+    rev: v2.2.3
     hooks:
       - id: check-json
       - id: check-merge-conflict
@@ -12,12 +12,12 @@ repos:
       - id: trailing-whitespace
 
   - repo: git://github.com/igorshubovych/markdownlint-cli
-    rev: v0.13.0
+    rev: v0.17.0
     hooks:
       - id: markdownlint
 
   - repo: git://github.com/antonbabenko/pre-commit-terraform
-    rev: v1.7.3
+    rev: v1.12.0
     hooks:
       - id: terraform_docs
       - id: terraform_fmt

--- a/README.md
+++ b/README.md
@@ -14,10 +14,10 @@ Creates the following resources:
 ## Usage
 
 ```hcl
-module "packer-janitor-lambda" {
+module "packerjanitor-lambda" {
   source                 = "trussworks/lambda-packerjanitor/aws"
-  packer_resource_delete = "true"
-  packer_timelimit       = "4"
+  packer_resource_delete = true
+  packer_timelimit       = "2"
   job_identifier         = "sample_app"
   s3_bucket              = "sample_app_lambdas"
   version_to_deploy      = "2.8"

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ well as how to deploy it, see <https://github.com/trussworks/truss-aws-tools>.
 | Name | Description | Type | Default | Required |
 |------|-------------|:----:|:-----:|:-----:|
 | cloudwatch\_logs\_retention\_days | Number of days to retain Cloudwatch logs. Default is 90 days. | string | `"90"` | no |
-| interval\_minutes | How often to run the packer janitor, in minutes. Default is 240 (4 hours). | string | `"240"` | no |
+| interval\_minutes | How often to run the packer janitor, in minutes. Default is 60 (1 hour). | string | `"60"` | no |
 | job\_identifier | A generic job identifier to make resources for this job more obvious. | string | n/a | yes |
 | packer\_resource\_delete | Perform the actual delete of abandoned Packer resources | string | n/a | yes |
 | packer\_timelimit | Number of hours after which a Packer instance will be considered abandoned. Default is 4 hours. | string | `"4"` | no |

--- a/README.md
+++ b/README.md
@@ -1,0 +1,48 @@
+<!-- BEGINNING OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
+Creates a Lambda function with associated role and policies that
+will run the packer-janitor tool to get rid of orphaned Packer
+instances and their associated resources.
+
+Creates the following resources:
+
+* Lambda function
+* IAM role and policies to describe and delete instances, keypairs,
+  and security groups, as well as write messages to Cloudwatch Logs
+* Cloudwatch Logs group
+* Cloudwatch Event to regularly run cleanup job
+
+## Usage
+
+```hcl
+module "packer-janitor-lambda" {
+  source                 = "trussworks/lambda-packerjanitor/aws"
+  packer_resource_delete = "true"
+  packer_timelimit       = "4"
+  job_identifier         = "sample_app"
+  s3_bucket              = "sample_app_lambdas"
+  version_to_deploy      = "2.8"
+}
+```
+
+For more details on the capabilities of the packer-janitor tool, as
+well as how to deploy it, see <https://github.com/trussworks/truss-aws-tools>.
+
+## Inputs
+
+| Name | Description | Type | Default | Required |
+|------|-------------|:----:|:-----:|:-----:|
+| cloudwatch\_logs\_retention\_days | Number of days to retain Cloudwatch logs. Default is 90 days. | string | `"90"` | no |
+| interval\_minutes | How often to run the packer janitor, in minutes. Default is 240 (4 hours). | string | `"240"` | no |
+| job\_identifier | A generic job identifier to make resources for this job more obvious. | string | n/a | yes |
+| packer\_resource\_delete | Perform the actual delete of abandoned Packer resources | string | n/a | yes |
+| packer\_timelimit | Number of hours after which a Packer instance will be considered abandoned. Default is 4 hours. | string | `"4"` | no |
+| s3\_bucket | The name of the bucket used to store the Lambda builds. | string | n/a | yes |
+| version\_to\_deploy | The version of the Lambda function to deploy. | string | n/a | yes |
+
+## Outputs
+
+| Name | Description |
+|------|-------------|
+| lambda\_arn | ARN for the packerjanitor lambda function |
+
+<!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->

--- a/main.tf
+++ b/main.tf
@@ -30,7 +30,7 @@
 
 locals {
   pkg  = "truss-aws-tools"
-  name = "ami-cleaner"
+  name = "packer-janitor"
 }
 
 data "aws_region" "current" {}

--- a/main.tf
+++ b/main.tf
@@ -1,0 +1,138 @@
+/**
+ * Creates a Lambda function with associated role and policies that
+ * will run the packer-janitor tool to get rid of orphaned Packer
+ * instances and their associated resources.
+ *
+ * Creates the following resources:
+ *
+ * * Lambda function
+ * * IAM role and policies to describe and delete instances, keypairs,
+ *   and security groups, as well as write messages to Cloudwatch Logs
+ * * Cloudwatch Logs group
+ * * Cloudwatch Event to regularly run cleanup job
+ *
+ * ## Usage
+ *
+ * ```hcl
+ * module "packer-janitor-lambda" {
+ *   source                 = "trussworks/lambda-packerjanitor/aws"
+ *   packer_resource_delete = "true"
+ *   packer_timelimit       = "4"
+ *   job_identifier         = "sample_app"
+ *   s3_bucket              = "sample_app_lambdas"
+ *   version_to_deploy      = "2.8"
+ * }
+ * ```
+ *
+ * For more details on the capabilities of the packer-janitor tool, as
+ * well as how to deploy it, see <https://github.com/trussworks/truss-aws-tools>.
+ */
+
+locals {
+  pkg  = "truss-aws-tools"
+  name = "ami-cleaner"
+}
+
+data "aws_region" "current" {}
+
+# This is the main policy this job is going to need.
+data "aws_iam_policy_document" "main" {
+  # Allow describing instances, keypairs, and security groups.
+  statement {
+    sid    = "Describes"
+    effect = "Allow"
+
+    actions = [
+      "ec2:DescribeInstances",
+      "ec2:DescribeKeyPairs",
+      "ec2:DescribeSecurityGroups",
+    ]
+
+    resources = ["*"]
+  }
+
+  # Allow terminating EC2 Instances
+  statement {
+    sid    = "TerminateInstances"
+    effect = "Allow"
+
+    actions = [
+      "ec2:TerminateInstances",
+    ]
+
+    resources = ["*"]
+  }
+
+  # Allow deleting key pairs.
+  statement {
+    sid    = "DeleteKeyPair"
+    effect = "Allow"
+
+    actions = [
+      "ec2:DeleteKeyPair",
+    ]
+
+    resources = ["*"]
+  }
+
+  # Allow deleting security groups.
+  statement {
+    sid    = "DeleteSecurityGroup"
+    effect = "Allow"
+
+    actions = [
+      "ec2:DeleteSecurityGroup",
+    ]
+
+    resources = ["*"]
+  }
+}
+
+# Create the policy for the document we just added above.
+resource "aws_iam_policy" "main" {
+  name   = "${local.name}-${var.job_identifier}-policy"
+  policy = "${data.aws_iam_policy_document.main.json}"
+}
+
+# Lambda function
+module "packerjanitor_lambda" {
+  source  = "trussworks/lambda/aws"
+  version = "~>1.0.1"
+
+  name                           = "${local.name}"
+  job_identifier                 = "${var.job_identifier}"
+  runtime                        = "go1.x"
+  role_policy_arns_count         = 1
+  role_policy_arns               = ["${aws_iam_policy.main.arn}"]
+  cloudwatch_logs_retention_days = "${var.cloudwatch_logs_retention_days}"
+
+  s3_bucket = "${var.s3_bucket}"
+  s3_key    = "${local.pkg}/${var.version_to_deploy}/${local.pkg}.zip"
+
+  source_types = ["events"]
+  source_arns  = ["${aws_cloudwatch_event_rule.main.arn}"]
+
+  env_vars {
+    DELETE    = "${var.packer_resource_delete}"
+    TIMELIMIT = "${var.packer_timelimit}"
+
+    # This will run the Packer janitor with its Lambda handler.
+    LAMBDA = true
+  }
+
+  tags {
+    Name = "${local.name}-${var.job_identifier}"
+  }
+}
+
+# Cloudwatch event for regular running of the Lambda function.
+resource "aws_cloudwatch_event_rule" "main" {
+  name                = "${local.name}-${var.job_identifier}"
+  description         = "scheduled trigger for ${local.name}"
+  schedule_expression = "rate(${var.interval_minutes} minutes)"
+}
+
+resource "aws_cloudwatch_event_target" "main" {
+  rule = "${aws_cloudwatch_event_rule.main.name}"
+  arn  = "${module.packerjanitor_lambda.lambda_arn}"
+}

--- a/main.tf
+++ b/main.tf
@@ -61,6 +61,15 @@ data "aws_iam_policy_document" "main" {
     ]
 
     resources = ["*"]
+
+    condition {
+      test     = "StringLike"
+      variable = "ec2:ResourceTag/Name"
+
+      values = [
+        "Packer Builder",
+      ]
+    }
   }
 
   # Allow deleting key pairs.

--- a/main.tf
+++ b/main.tf
@@ -14,10 +14,10 @@
  * ## Usage
  *
  * ```hcl
- * module "packer-janitor-lambda" {
+ * module "packerjanitor-lambda" {
  *   source                 = "trussworks/lambda-packerjanitor/aws"
- *   packer_resource_delete = "true"
- *   packer_timelimit       = "4"
+ *   packer_resource_delete = true
+ *   packer_timelimit       = "2"
  *   job_identifier         = "sample_app"
  *   s3_bucket              = "sample_app_lambdas"
  *   version_to_deploy      = "2.8"

--- a/outputs.tf
+++ b/outputs.tf
@@ -1,0 +1,4 @@
+output "lambda_arn" {
+  description = "ARN for the packerjanitor lambda function"
+  value       = "${module.packerjanitor_lambda.lambda_arn}"
+}

--- a/variables.tf
+++ b/variables.tf
@@ -1,0 +1,37 @@
+variable "cloudwatch_logs_retention_days" {
+  default     = 90
+  description = "Number of days to retain Cloudwatch logs. Default is 90 days."
+  type        = "string"
+}
+
+variable "interval_minutes" {
+  default     = 240
+  description = "How often to run the packer janitor, in minutes. Default is 240 (4 hours)."
+  type        = "string"
+}
+
+variable "job_identifier" {
+  description = "A generic job identifier to make resources for this job more obvious."
+  type        = "string"
+}
+
+variable "packer_resource_delete" {
+  description = "Perform the actual delete of abandoned Packer resources"
+  type        = "string"
+}
+
+variable "packer_timelimit" {
+  default     = 4
+  description = "Number of hours after which a Packer instance will be considered abandoned. Default is 4 hours."
+  type        = "string"
+}
+
+variable "s3_bucket" {
+  description = "The name of the bucket used to store the Lambda builds."
+  type        = "string"
+}
+
+variable "version_to_deploy" {
+  description = "The version of the Lambda function to deploy."
+  type        = "string"
+}

--- a/variables.tf
+++ b/variables.tf
@@ -5,8 +5,8 @@ variable "cloudwatch_logs_retention_days" {
 }
 
 variable "interval_minutes" {
-  default     = 240
-  description = "How often to run the packer janitor, in minutes. Default is 240 (4 hours)."
+  default     = 60
+  description = "How often to run the packer janitor, in minutes. Default is 60 (1 hour)."
   type        = "string"
 }
 


### PR DESCRIPTION
This is my initial work on a terraform module to add a lambda job for the packer-janitor tool; I've included a test run of this against the git commit.

Terraform plan (updated to commit 190addf7):
```
An execution plan has been generated and is shown below.
Resource actions are indicated with the following symbols:
  + create

Terraform will perform the following actions:

  + module.packer-janitor.aws_cloudwatch_event_rule.main
      id:                                <computed>
      arn:                               <computed>
      description:                       "scheduled trigger for packer-janitor"
      is_enabled:                        "true"
      name:                              "packer-janitor-gi-prod"
      schedule_expression:               "rate(60 minutes)"

  + module.packer-janitor.aws_cloudwatch_event_target.main
      id:                                <computed>
      arn:                               "${module.packerjanitor_lambda.lambda_arn}"
      rule:                              "packer-janitor-gi-prod"
      target_id:                         <computed>

  + module.packer-janitor.aws_iam_policy.main
      id:                                <computed>
      arn:                               <computed>
      name:                              "packer-janitor-gi-prod-policy"
      path:                              "/"
      policy:                            "{\n  \"Version\": \"2012-10-17\",\n  \"Statement\": [\n    {\n      \"Sid\": \"Describes\",\n      \"Effect\": \"Allow\",\n      \"Action\": [\n        \"ec2:DescribeSecurityGroups\",\n        \"ec2:DescribeKeyPairs\",\n        \"ec2:DescribeInstances\"\n      ],\n      \"Resource\": \"*\"\n    },\n    {\n      \"Sid\": \"TerminateInstances\",\n      \"Effect\": \"Allow\",\n      \"Action\": \"ec2:TerminateInstances\",\n      \"Resource\": \"*\",\n      \"Condition\": {\n        \"StringLike\": {\n          \"ec2:ResourceTag/Name\": \"Packer Builder\"\n        }\n      }\n    },\n    {\n      \"Sid\": \"DeleteKeyPair\",\n      \"Effect\": \"Allow\",\n      \"Action\": \"ec2:DeleteKeyPair\",\n      \"Resource\": \"*\"\n    },\n    {\n      \"Sid\": \"DeleteSecurityGroup\",\n      \"Effect\": \"Allow\",\n      \"Action\": \"ec2:DeleteSecurityGroup\",\n      \"Resource\": \"*\"\n    }\n  ]\n}"

  + module.packer-janitor.module.packerjanitor_lambda.aws_cloudwatch_log_group.main
      id:                                <computed>
      arn:                               <computed>
      name:                              "/aws/lambda/packer-janitor-gi-prod"
      retention_in_days:                 "3653"
      tags.%:                            "1"
      tags.Name:                         "packer-janitor-gi-prod"

  + module.packer-janitor.module.packerjanitor_lambda.aws_iam_role.main
      id:                                <computed>
      arn:                               <computed>
      assume_role_policy:                "{\n  \"Version\": \"2012-10-17\",\n  \"Statement\": [\n    {\n      \"Sid\": \"\",\n      \"Effect\": \"Allow\",\n      \"Action\": \"sts:AssumeRole\",\n      \"Principal\": {\n        \"Service\": \"lambda.amazonaws.com\"\n      }\n    }\n  ]\n}"
      create_date:                       <computed>
      force_detach_policies:             "false"
      max_session_duration:              "3600"
      name:                              "lambda-packer-janitor-gi-prod"
      path:                              "/"
      unique_id:                         <computed>

  + module.packer-janitor.module.packerjanitor_lambda.aws_iam_role_policy.main
      id:                                <computed>
      name:                              "lambda-packer-janitor-gi-prod"
      policy:                            "{\n  \"Version\": \"2012-10-17\",\n  \"Statement\": [\n    {\n      \"Sid\": \"WriteCloudWatchLogs\",\n      \"Effect\": \"Allow\",\n      \"Action\": [\n        \"logs:PutLogEvents\",\n        \"logs:CreateLogStream\"\n      ],\n      \"Resource\": \"arn:aws:logs:us-west-2:743302140042:log-group:/aws/lambda/packer-janitor-gi-prod:*\"\n    }\n  ]\n}"
      role:                              "${aws_iam_role.main.id}"

  + module.packer-janitor.module.packerjanitor_lambda.aws_iam_role_policy_attachment.user_policy_attach
      id:                                <computed>
      policy_arn:                        "${var.role_policy_arns[count.index]}"
      role:                              "lambda-packer-janitor-gi-prod"

  + module.packer-janitor.module.packerjanitor_lambda.aws_lambda_function.main
      id:                                <computed>
      arn:                               <computed>
      environment.#:                     "1"
      environment.0.variables.%:         "3"
      environment.0.variables.DELETE:    "true"
      environment.0.variables.LAMBDA:    "1"
      environment.0.variables.TIMELIMIT: "4"
      function_name:                     "packer-janitor-gi-prod"
      handler:                           "packer-janitor"
      invoke_arn:                        <computed>
      last_modified:                     <computed>
      memory_size:                       "128"
      publish:                           "false"
      qualified_arn:                     <computed>
      reserved_concurrent_executions:    "-1"
      role:                              "${aws_iam_role.main.arn}"
      runtime:                           "go1.x"
      s3_bucket:                         "aws-cms-oit-iusg-draas-gi-prod-lambda-builds-us-west-2"
      s3_key:                            "truss-aws-tools/2.8/truss-aws-tools.zip"
      source_code_hash:                  <computed>
      source_code_size:                  <computed>
      tags.%:                            "1"
      tags.Name:                         "packer-janitor-gi-prod"
      timeout:                           "60"
      tracing_config.#:                  <computed>
      version:                           <computed>
      vpc_config.#:                      "1"
      vpc_config.0.vpc_id:               <computed>

  + module.packer-janitor.module.packerjanitor_lambda.aws_lambda_permission.allow_source
      id:                                <computed>
      action:                            "lambda:InvokeFunction"
      function_name:                     "packer-janitor-gi-prod"
      principal:                         "events.amazonaws.com"
      source_arn:                        "${var.source_arns[count.index]}"
      statement_id:                      "AllowExecutionForLambda-events"

  + module.packer-janitor.module.packerjanitor_lambda.null_resource.verify_policy_list_count
      id:                                <computed>
      triggers.%:                        <computed>


Plan: 10 to add, 0 to change, 0 to destroy.
```