### PR TITLE
Replace circleci-docker-primary; upgrade to terraform 13; upgrade aws provider

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@ version: 2
 jobs:
   validate:
     docker:
-      - image: trussworks/circleci-docker-primary:a18ba9987556eec2e48354848a3c9fb4d5b69ac8
+      - image: trussworks/circleci:29ab89fdada1f85c5d8fb685a2c71660f0c5f60c
     steps:
       - checkout
       - restore_cache:

--- a/.markdownlintrc
+++ b/.markdownlintrc
@@ -3,5 +3,6 @@
   "first-header-h1": false,
   "first-line-h1": false,
   "line_length": false,
-  "no-multiple-blanks": false
+  "no-multiple-blanks": false,
+  "no-inline-html": false
 }

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
   - repo: git://github.com/pre-commit/pre-commit-hooks
-    rev: v2.2.3
+    rev: v3.2.0
     hooks:
       - id: check-json
       - id: check-merge-conflict
@@ -12,13 +12,12 @@ repos:
       - id: trailing-whitespace
 
   - repo: git://github.com/igorshubovych/markdownlint-cli
-    rev: v0.17.0
+    rev: v0.23.2
     hooks:
       - id: markdownlint
 
   - repo: git://github.com/antonbabenko/pre-commit-terraform
-    rev: v1.12.0
+    rev: v1.37.0
     hooks:
       - id: terraform_docs
       - id: terraform_fmt
-      - id: terraform_validate_no_variables

--- a/README.md
+++ b/README.md
@@ -1,4 +1,3 @@
-<!-- BEGINNING OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
 Creates a Lambda function with associated role and policies that
 will run the packer-janitor tool to get rid of orphaned Packer
 instances and their associated resources.
@@ -7,6 +6,25 @@ Creates the following resources:
 
 * Lambda function
 * IAM role and policies to describe and delete instances, keypairs,
+  and security groups, as well as write messages to Cloudwatch Logs
+* Cloudwatch Logs group
+* Cloudwatch Event to regularly run cleanup job
+
+## Terraform Versions
+
+Terraform 0.13: Pin module version to ~> 2.X. Submit pull requests to master branch.
+
+Terraform 0.12: Pin module version to ~> 1.X. Submit pull requests to terraform012 branch.
+
+<!-- BEGINNING OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
+Creates a Lambda function with associated role and policies that  
+will run the packer-janitor tool to get rid of orphaned Packer  
+instances and their associated resources.
+
+Creates the following resources:
+
+* Lambda function
+* IAM role and policies to describe and delete instances, keypairs,  
   and security groups, as well as write messages to Cloudwatch Logs
 * Cloudwatch Logs group
 * Cloudwatch Event to regularly run cleanup job
@@ -24,20 +42,33 @@ module "packerjanitor-lambda" {
 }
 ```
 
-For more details on the capabilities of the packer-janitor tool, as
+For more details on the capabilities of the packer-janitor tool, as  
 well as how to deploy it, see <https://github.com/trussworks/truss-aws-tools>.
+
+## Requirements
+
+| Name | Version |
+|------|---------|
+| terraform | ~> 0.13.0 |
+| aws | ~> 3.0 |
+
+## Providers
+
+| Name | Version |
+|------|---------|
+| aws | ~> 3.0 |
 
 ## Inputs
 
 | Name | Description | Type | Default | Required |
-|------|-------------|:----:|:-----:|:-----:|
-| cloudwatch\_logs\_retention\_days | Number of days to retain Cloudwatch logs. Default is 90 days. | string | `"90"` | no |
-| interval\_minutes | How often to run the packer janitor, in minutes. Default is 60 (1 hour). | string | `"60"` | no |
-| job\_identifier | A generic job identifier to make resources for this job more obvious. | string | n/a | yes |
-| packer\_resource\_delete | Perform the actual delete of abandoned Packer resources | string | n/a | yes |
-| packer\_timelimit | Number of hours after which a Packer instance will be considered abandoned. Default is 4 hours. | string | `"4"` | no |
-| s3\_bucket | The name of the bucket used to store the Lambda builds. | string | n/a | yes |
-| version\_to\_deploy | The version of the Lambda function to deploy. | string | n/a | yes |
+|------|-------------|------|---------|:--------:|
+| cloudwatch\_logs\_retention\_days | Number of days to retain Cloudwatch logs. Default is 90 days. | `string` | `90` | no |
+| interval\_minutes | How often to run the packer janitor, in minutes. Default is 60 (1 hour). | `string` | `60` | no |
+| job\_identifier | A generic job identifier to make resources for this job more obvious. | `string` | n/a | yes |
+| packer\_resource\_delete | Perform the actual delete of abandoned Packer resources | `string` | n/a | yes |
+| packer\_timelimit | Number of hours after which a Packer instance will be considered abandoned. Default is 4 hours. | `string` | `4` | no |
+| s3\_bucket | The name of the bucket used to store the Lambda builds. | `string` | n/a | yes |
+| version\_to\_deploy | The version of the Lambda function to deploy. | `string` | n/a | yes |
 
 ## Outputs
 

--- a/versions.tf
+++ b/versions.tf
@@ -1,0 +1,7 @@
+terraform {
+  required_version = "~> 0.13.0"
+
+  required_providers {
+    aws = "~> 3.0"
+  }
+}


### PR DESCRIPTION
# [Tracker story](https://www.pivotaltracker.com/story/show/174581758)

<!--
    Insert the tracker story URL in the markdown link above
    e.g., Fixes [#1324235](http://path/to/storyid/1324235)
--->

Changes proposed in this pull request:

- Replace `circleci-docker-primary` with `circleci` docker images
- Upgrade to terraform 13 since `circleci` is built with that version of TF
- Upgrade to AWS provider 3.0

## Checklist for Terraform changes

<!--
    - [x] a checked item
    - [ ] an unchecked item
-->

- [ ] Type `atlantis plan` as a Github comment to share your Terraform plan
- [ ] Get PR approval
- [ ] Type `atlantis apply`as a Github comment to apply and merge the plan

If the apply is successful, Atlantis will delete the branch and plan file.

---
<details><summary>Terraform plan</summary>

```terraform
Add Terraform plan here
```

</details>
